### PR TITLE
Integrated websocket server example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,5 @@ FAKTORY_URL=tcp://localhost:7419
 FAKTORY_PASSWORD=''
 DATABASE_URL=postgres://postgres:password@127.0.0.1:5432/startup
 SENDGRID_API_KEY='YOUR_API_KEY'
+REDIS_WS_SERVER=redis://:password@localhost:6379
+REDIS_WS_PASSWORD=password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,20 @@ services:
     ports:
       - '7419:7419'
       - '7420:7420'
+  websocket-kv:
+    image: redis:alpine
+    command: redis-server --save 20 1 --loglevel warning --requirepass $REDIS_WS_PASSWORD
+    restart: always
+    ports:
+      - '6379:6379'
+    volumes:
+      - websocket-kv:/data
+    env_file:
+      - .env
 
 # create local volume for postgres data to persist through computer restarts
 volumes:
   postgres-data:
+    driver: local
+  websocket-kv:
     driver: local

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
 		"build": "vite build",
 		"build:render": "bash ./render-build.sh",
 		"preview": "vite preview",
+		"prod": "tsm ./prod-server.ts",
 		"test": "npm run test:integration && npm run test:unit",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
@@ -31,6 +32,7 @@
 		"@sveltejs/adapter-auto": "^2.1.0",
 		"@sveltejs/adapter-node": "^1.3.1",
 		"@sveltejs/kit": "^1.26.0",
+		"@types/ws": "^8.5.9",
 		"@typescript-eslint/eslint-plugin": "^6.8.0",
 		"@typescript-eslint/parser": "^6.8.0",
 		"autoprefixer": "^10.4.14",
@@ -48,6 +50,7 @@
 		"svelte-headless-table": "^0.17.7",
 		"tailwindcss": "^3.3.2",
 		"tslib": "^2.6.2",
+		"tsm": "^2.3.0",
 		"typescript": "^5.2.2",
 		"vite": "^4.5.0",
 		"vitest": "^0.32.4"
@@ -60,12 +63,15 @@
 		"drizzle-orm": "^0.28.6",
 		"faktory-worker": "^4.5.1",
 		"formsnap": "^0.2.0",
+		"ioredis": "^5.3.2",
 		"lucia": "^2.7.1",
 		"lucide-svelte": "^0.288.0",
+		"nanoid": "^5.0.3",
 		"postgres": "^3.4.0",
 		"sveltekit-superforms": "^1.8.0",
 		"tailwind-merge": "^1.14.0",
 		"tailwind-variants": "^0.1.14",
+		"ws": "^8.14.2",
 		"zod": "^3.22.4"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ dependencies:
     version: 2.0.1(lucia@2.7.1)(postgres@3.4.0)
   bits-ui:
     specifier: ^0.6.2
-    version: 0.6.2(svelte@4.2.2)
+    version: 0.6.2(svelte@4.2.5)
   clsx:
     specifier: ^2.0.0
     version: 2.0.0
@@ -22,25 +22,34 @@ dependencies:
     version: 4.5.1
   formsnap:
     specifier: ^0.2.0
-    version: 0.2.0(svelte@4.2.2)(sveltekit-superforms@1.8.0)(zod@3.22.4)
+    version: 0.2.0(svelte@4.2.5)(sveltekit-superforms@1.8.0)(zod@3.22.4)
+  ioredis:
+    specifier: ^5.3.2
+    version: 5.3.2
   lucia:
     specifier: ^2.7.1
     version: 2.7.1
   lucide-svelte:
     specifier: ^0.288.0
-    version: 0.288.0(svelte@4.2.2)
+    version: 0.288.0(svelte@4.2.5)
+  nanoid:
+    specifier: ^5.0.3
+    version: 5.0.3
   postgres:
     specifier: ^3.4.0
     version: 3.4.0
   sveltekit-superforms:
     specifier: ^1.8.0
-    version: 1.8.0(@sveltejs/kit@1.26.0)(svelte@4.2.2)(zod@3.22.4)
+    version: 1.8.0(@sveltejs/kit@1.26.0)(svelte@4.2.5)(zod@3.22.4)
   tailwind-merge:
     specifier: ^1.14.0
     version: 1.14.0
   tailwind-variants:
     specifier: ^0.1.14
     version: 0.1.14(tailwindcss@3.3.3)
+  ws:
+    specifier: ^8.14.2
+    version: 8.14.2
   zod:
     specifier: ^3.22.4
     version: 3.22.4
@@ -57,7 +66,10 @@ devDependencies:
     version: 1.3.1(@sveltejs/kit@1.26.0)
   '@sveltejs/kit':
     specifier: ^1.26.0
-    version: 1.26.0(svelte@4.2.2)(vite@4.5.0)
+    version: 1.26.0(svelte@4.2.5)(vite@4.5.0)
+  '@types/ws':
+    specifier: ^8.5.9
+    version: 8.5.9
   '@typescript-eslint/eslint-plugin':
     specifier: ^6.8.0
     version: 6.8.0(@typescript-eslint/parser@6.8.0)(eslint@8.52.0)(typescript@5.2.2)
@@ -81,7 +93,7 @@ devDependencies:
     version: 8.10.0(eslint@8.52.0)
   eslint-plugin-svelte:
     specifier: ^2.34.0
-    version: 2.34.0(eslint@8.52.0)(svelte@4.2.2)
+    version: 2.34.0(eslint@8.52.0)(svelte@4.2.5)
   postcss:
     specifier: ^8.4.24
     version: 8.4.31
@@ -93,22 +105,25 @@ devDependencies:
     version: 2.8.8
   prettier-plugin-svelte:
     specifier: ^2.10.1
-    version: 2.10.1(prettier@2.8.8)(svelte@4.2.2)
+    version: 2.10.1(prettier@2.8.8)(svelte@4.2.5)
   svelte:
     specifier: ^4.2.2
-    version: 4.2.2
+    version: 4.2.5
   svelte-check:
     specifier: ^3.5.2
-    version: 3.5.2(postcss-load-config@4.0.1)(postcss@8.4.31)(svelte@4.2.2)
+    version: 3.5.2(postcss-load-config@4.0.1)(postcss@8.4.31)(svelte@4.2.5)
   svelte-headless-table:
     specifier: ^0.17.7
-    version: 0.17.7(svelte@4.2.2)
+    version: 0.17.7(svelte@4.2.5)
   tailwindcss:
     specifier: ^3.3.2
     version: 3.3.3
   tslib:
     specifier: ^2.6.2
     version: 2.6.2
+  tsm:
+    specifier: ^2.3.0
+    version: 2.3.0
   typescript:
     specifier: ^5.2.2
     version: 5.2.2
@@ -161,6 +176,15 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
+    optional: true
+
+  /@esbuild/android-arm@0.15.18:
+    resolution: {integrity: sha512-5GT+kcs2WVGjVs7+boataCkO5Fg0y4kCjzkB5bAip7H4jfnOS3dA6KPiww9W1OEKTKeAcUVhdZGvgI65OXmUnw==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/android-arm@0.18.20:
@@ -233,6 +257,15 @@ packages:
     cpu: [ia32]
     os: [linux]
     requiresBuild: true
+    optional: true
+
+  /@esbuild/linux-loong64@0.15.18:
+    resolution: {integrity: sha512-L4jVKS82XVhw2nvzLg/19ClLWg0y27ulRwuP7lcyL6AbUWB5aPglXY3M21mauDQMDfRLs8cQmeT03r/+X3cZYQ==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-loong64@0.18.20:
@@ -409,6 +442,10 @@ packages:
     resolution: {integrity: sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==}
     dev: true
 
+  /@ioredis/commands@1.2.0:
+    resolution: {integrity: sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==}
+    dev: false
+
   /@jest/schemas@29.6.3:
     resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -457,7 +494,7 @@ packages:
       postgres: 3.4.0
     dev: false
 
-  /@melt-ui/svelte@0.55.3(svelte@4.2.2):
+  /@melt-ui/svelte@0.55.3(svelte@4.2.5):
     resolution: {integrity: sha512-KT9/14LRk5gaUgd2aywUmCpm3jq4RCTIyIvhktKCkP5v/OSsyftkLti6j9uySWNuNeUR4VGBChkT8/sR/bOUyw==}
     peerDependencies:
       svelte: '>=3 <5'
@@ -467,7 +504,7 @@ packages:
       dequal: 2.0.3
       focus-trap: 7.5.4
       nanoid: 4.0.2
-      svelte: 4.2.2
+      svelte: 4.2.5
     dev: false
 
   /@nodelib/fs.scandir@2.1.5:
@@ -572,7 +609,7 @@ packages:
     peerDependencies:
       '@sveltejs/kit': ^1.0.0
     dependencies:
-      '@sveltejs/kit': 1.26.0(svelte@4.2.2)(vite@4.5.0)
+      '@sveltejs/kit': 1.26.0(svelte@4.2.5)(vite@4.5.0)
       import-meta-resolve: 3.0.0
     dev: true
 
@@ -584,11 +621,11 @@ packages:
       '@rollup/plugin-commonjs': 25.0.7(rollup@3.29.4)
       '@rollup/plugin-json': 6.0.1(rollup@3.29.4)
       '@rollup/plugin-node-resolve': 15.2.3(rollup@3.29.4)
-      '@sveltejs/kit': 1.26.0(svelte@4.2.2)(vite@4.5.0)
+      '@sveltejs/kit': 1.26.0(svelte@4.2.5)(vite@4.5.0)
       rollup: 3.29.4
     dev: true
 
-  /@sveltejs/kit@1.26.0(svelte@4.2.2)(vite@4.5.0):
+  /@sveltejs/kit@1.26.0(svelte@4.2.5)(vite@4.5.0):
     resolution: {integrity: sha512-CV/AlTziC05yrz7UjVqEd0pH6+2dnrbmcnHGr2d3jXtmOgzNnlDkXtX8g3BfJ6nntsPD+0jtS2PzhvRHblRz4A==}
     engines: {node: ^16.14 || >=18}
     hasBin: true
@@ -597,7 +634,7 @@ packages:
       svelte: ^3.54.0 || ^4.0.0-next.0
       vite: ^4.0.0
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 2.4.6(svelte@4.2.2)(vite@4.5.0)
+      '@sveltejs/vite-plugin-svelte': 2.4.6(svelte@4.2.5)(vite@4.5.0)
       '@types/cookie': 0.5.3
       cookie: 0.5.0
       devalue: 4.3.2
@@ -608,14 +645,14 @@ packages:
       sade: 1.8.1
       set-cookie-parser: 2.6.0
       sirv: 2.0.3
-      svelte: 4.2.2
+      svelte: 4.2.5
       tiny-glob: 0.2.9
       undici: 5.26.4
       vite: 4.5.0(@types/node@20.8.7)
     transitivePeerDependencies:
       - supports-color
 
-  /@sveltejs/vite-plugin-svelte-inspector@1.0.4(@sveltejs/vite-plugin-svelte@2.4.6)(svelte@4.2.2)(vite@4.5.0):
+  /@sveltejs/vite-plugin-svelte-inspector@1.0.4(@sveltejs/vite-plugin-svelte@2.4.6)(svelte@4.2.5)(vite@4.5.0):
     resolution: {integrity: sha512-zjiuZ3yydBtwpF3bj0kQNV0YXe+iKE545QGZVTaylW3eAzFr+pJ/cwK8lZEaRp4JtaJXhD5DyWAV4AxLh6DgaQ==}
     engines: {node: ^14.18.0 || >= 16}
     peerDependencies:
@@ -623,27 +660,27 @@ packages:
       svelte: ^3.54.0 || ^4.0.0
       vite: ^4.0.0
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 2.4.6(svelte@4.2.2)(vite@4.5.0)
+      '@sveltejs/vite-plugin-svelte': 2.4.6(svelte@4.2.5)(vite@4.5.0)
       debug: 4.3.4
-      svelte: 4.2.2
+      svelte: 4.2.5
       vite: 4.5.0(@types/node@20.8.7)
     transitivePeerDependencies:
       - supports-color
 
-  /@sveltejs/vite-plugin-svelte@2.4.6(svelte@4.2.2)(vite@4.5.0):
+  /@sveltejs/vite-plugin-svelte@2.4.6(svelte@4.2.5)(vite@4.5.0):
     resolution: {integrity: sha512-zO79p0+DZnXPnF0ltIigWDx/ux7Ni+HRaFOw720Qeivc1azFUrJxTl0OryXVibYNx1hCboGia1NRV3x8RNv4cA==}
     engines: {node: ^14.18.0 || >= 16}
     peerDependencies:
       svelte: ^3.54.0 || ^4.0.0
       vite: ^4.0.0
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 1.0.4(@sveltejs/vite-plugin-svelte@2.4.6)(svelte@4.2.2)(vite@4.5.0)
+      '@sveltejs/vite-plugin-svelte-inspector': 1.0.4(@sveltejs/vite-plugin-svelte@2.4.6)(svelte@4.2.5)(vite@4.5.0)
       debug: 4.3.4
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.5
-      svelte: 4.2.2
-      svelte-hmr: 0.15.3(svelte@4.2.2)
+      svelte: 4.2.5
+      svelte-hmr: 0.15.3(svelte@4.2.5)
       vite: 4.5.0(@types/node@20.8.7)
       vitefu: 0.2.5(vite@4.5.0)
     transitivePeerDependencies:
@@ -684,6 +721,12 @@ packages:
 
   /@types/semver@7.5.4:
     resolution: {integrity: sha512-MMzuxN3GdFwskAnb6fz0orFvhfqi752yjaXylr0Rp4oDg5H0Zn1IuyRhDVvYOwAXoJirx2xuS16I3WjxnAIHiQ==}
+    dev: true
+
+  /@types/ws@8.5.9:
+    resolution: {integrity: sha512-jbdrY0a8lxfdTp/+r7Z4CkycbOFN8WX+IOchLJr3juT/xzbJ8URyTVSJ/hvNdadTgM1mnedb47n+Y31GsFnQlg==}
+    dependencies:
+      '@types/node': 20.8.7
     dev: true
 
   /@typescript-eslint/eslint-plugin@6.8.0(@typescript-eslint/parser@6.8.0)(eslint@8.52.0)(typescript@5.2.2):
@@ -962,14 +1005,14 @@ packages:
     resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
     engines: {node: '>=8'}
 
-  /bits-ui@0.6.2(svelte@4.2.2):
+  /bits-ui@0.6.2(svelte@4.2.5):
     resolution: {integrity: sha512-qzazG5CYZPKbDq32s6lP5spNEu7696cca5G/U6sccKIzS+CKwRYclP1OQ0dD+1AFY50HY3D3n1hxs4uBWlE+qA==}
     peerDependencies:
       svelte: ^4.0.0
     dependencies:
-      '@melt-ui/svelte': 0.55.3(svelte@4.2.2)
+      '@melt-ui/svelte': 0.55.3(svelte@4.2.5)
       nanoid: 4.0.2
-      svelte: 4.2.2
+      svelte: 4.2.5
     dev: false
 
   /brace-expansion@1.1.11:
@@ -1099,6 +1142,11 @@ packages:
     engines: {node: '>=6'}
     dev: false
 
+  /cluster-key-slot@1.1.2:
+    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
   /code-red@1.0.4:
     resolution: {integrity: sha512-7qJWqItLA8/VPVlKJlFXU+NBlo/qyfs39aJcuMT/2ere32ZqvF5OSxgdM5xOfJJ7O429gg2HM47y8v9P+9wrNw==}
     dependencies:
@@ -1191,6 +1239,11 @@ packages:
   /deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
+
+  /denque@2.1.0:
+    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
+    engines: {node: '>=0.10'}
+    dev: false
 
   /dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -1374,6 +1427,150 @@ packages:
       es6-symbol: 3.1.3
     dev: true
 
+  /esbuild-android-64@0.15.18:
+    resolution: {integrity: sha512-wnpt3OXRhcjfIDSZu9bnzT4/TNTDsOUvip0foZOUBG7QbSt//w3QV4FInVJxNhKc/ErhUxc5z4QjHtMi7/TbgA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-android-arm64@0.15.18:
+    resolution: {integrity: sha512-G4xu89B8FCzav9XU8EjsXacCKSG2FT7wW9J6hOc18soEHJdtWu03L3TQDGf0geNxfLTtxENKBzMSq9LlbjS8OQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-darwin-64@0.15.18:
+    resolution: {integrity: sha512-2WAvs95uPnVJPuYKP0Eqx+Dl/jaYseZEUUT1sjg97TJa4oBtbAKnPnl3b5M9l51/nbx7+QAEtuummJZW0sBEmg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-darwin-arm64@0.15.18:
+    resolution: {integrity: sha512-tKPSxcTJ5OmNb1btVikATJ8NftlyNlc8BVNtyT/UAr62JFOhwHlnoPrhYWz09akBLHI9nElFVfWSTSRsrZiDUA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-freebsd-64@0.15.18:
+    resolution: {integrity: sha512-TT3uBUxkteAjR1QbsmvSsjpKjOX6UkCstr8nMr+q7zi3NuZ1oIpa8U41Y8I8dJH2fJgdC3Dj3CXO5biLQpfdZA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-freebsd-arm64@0.15.18:
+    resolution: {integrity: sha512-R/oVr+X3Tkh+S0+tL41wRMbdWtpWB8hEAMsOXDumSSa6qJR89U0S/PpLXrGF7Wk/JykfpWNokERUpCeHDl47wA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-32@0.15.18:
+    resolution: {integrity: sha512-lphF3HiCSYtaa9p1DtXndiQEeQDKPl9eN/XNoBf2amEghugNuqXNZA/ZovthNE2aa4EN43WroO0B85xVSjYkbg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-64@0.15.18:
+    resolution: {integrity: sha512-hNSeP97IviD7oxLKFuii5sDPJ+QHeiFTFLoLm7NZQligur8poNOWGIgpQ7Qf8Balb69hptMZzyOBIPtY09GZYw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-arm64@0.15.18:
+    resolution: {integrity: sha512-54qr8kg/6ilcxd+0V3h9rjT4qmjc0CccMVWrjOEM/pEcUzt8X62HfBSeZfT2ECpM7104mk4yfQXkosY8Quptug==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-arm@0.15.18:
+    resolution: {integrity: sha512-UH779gstRblS4aoS2qpMl3wjg7U0j+ygu3GjIeTonCcN79ZvpPee12Qun3vcdxX+37O5LFxz39XeW2I9bybMVA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-mips64le@0.15.18:
+    resolution: {integrity: sha512-Mk6Ppwzzz3YbMl/ZZL2P0q1tnYqh/trYZ1VfNP47C31yT0K8t9s7Z077QrDA/guU60tGNp2GOwCQnp+DYv7bxQ==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-ppc64le@0.15.18:
+    resolution: {integrity: sha512-b0XkN4pL9WUulPTa/VKHx2wLCgvIAbgwABGnKMY19WhKZPT+8BxhZdqz6EgkqCLld7X5qiCY2F/bfpUUlnFZ9w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-riscv64@0.15.18:
+    resolution: {integrity: sha512-ba2COaoF5wL6VLZWn04k+ACZjZ6NYniMSQStodFKH/Pu6RxzQqzsmjR1t9QC89VYJxBeyVPTaHuBMCejl3O/xg==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-s390x@0.15.18:
+    resolution: {integrity: sha512-VbpGuXEl5FCs1wDVp93O8UIzl3ZrglgnSQ+Hu79g7hZu6te6/YHgVJxCM2SqfIila0J3k0csfnf8VD2W7u2kzQ==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-netbsd-64@0.15.18:
+    resolution: {integrity: sha512-98ukeCdvdX7wr1vUYQzKo4kQ0N2p27H7I11maINv73fVEXt2kyh4K4m9f35U1K43Xc2QGXlzAw0K9yoU7JUjOg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-openbsd-64@0.15.18:
+    resolution: {integrity: sha512-yK5NCcH31Uae076AyQAXeJzt/vxIo9+omZRKj1pauhk3ITuADzuOx5N2fdHrAKPxN+zH3w96uFKlY7yIn490xQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-register@3.5.0(esbuild@0.18.20):
     resolution: {integrity: sha512-+4G/XmakeBAsvJuDugJvtyF1x+XJT4FMocynNpxrvEBViirpfUn2PgNpCHedfWhF4WokNsO/OvMKrmJOIJsI5A==}
     peerDependencies:
@@ -1383,6 +1580,72 @@ packages:
       esbuild: 0.18.20
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /esbuild-sunos-64@0.15.18:
+    resolution: {integrity: sha512-On22LLFlBeLNj/YF3FT+cXcyKPEI263nflYlAhz5crxtp3yRG1Ugfr7ITyxmCmjm4vbN/dGrb/B7w7U8yJR9yw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-windows-32@0.15.18:
+    resolution: {integrity: sha512-o+eyLu2MjVny/nt+E0uPnBxYuJHBvho8vWsC2lV61A7wwTWC3jkN2w36jtA+yv1UgYkHRihPuQsL23hsCYGcOQ==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-windows-64@0.15.18:
+    resolution: {integrity: sha512-qinug1iTTaIIrCorAUjR0fcBk24fjzEedFYhhispP8Oc7SFvs+XeW3YpAKiKp8dRpizl4YYAhxMjlftAMJiaUw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-windows-arm64@0.15.18:
+    resolution: {integrity: sha512-q9bsYzegpZcLziq0zgUi5KqGVtfhjxGbnksaBFYmWLxeV/S1fK4OLdq2DFYnXcLMjlZw2L0jLsk1eGoB522WXQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild@0.15.18:
+    resolution: {integrity: sha512-x/R72SmW3sSFRm5zrrIjAhCeQSAWoni3CmHEqfQrZIQTM3lVCdehdwuIqaOtfC2slvpdlLa62GYoN8SxT23m6Q==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@esbuild/android-arm': 0.15.18
+      '@esbuild/linux-loong64': 0.15.18
+      esbuild-android-64: 0.15.18
+      esbuild-android-arm64: 0.15.18
+      esbuild-darwin-64: 0.15.18
+      esbuild-darwin-arm64: 0.15.18
+      esbuild-freebsd-64: 0.15.18
+      esbuild-freebsd-arm64: 0.15.18
+      esbuild-linux-32: 0.15.18
+      esbuild-linux-64: 0.15.18
+      esbuild-linux-arm: 0.15.18
+      esbuild-linux-arm64: 0.15.18
+      esbuild-linux-mips64le: 0.15.18
+      esbuild-linux-ppc64le: 0.15.18
+      esbuild-linux-riscv64: 0.15.18
+      esbuild-linux-s390x: 0.15.18
+      esbuild-netbsd-64: 0.15.18
+      esbuild-openbsd-64: 0.15.18
+      esbuild-sunos-64: 0.15.18
+      esbuild-windows-32: 0.15.18
+      esbuild-windows-64: 0.15.18
+      esbuild-windows-arm64: 0.15.18
     dev: true
 
   /esbuild@0.18.20:
@@ -1433,7 +1696,7 @@ packages:
       eslint: 8.52.0
     dev: true
 
-  /eslint-plugin-svelte@2.34.0(eslint@8.52.0)(svelte@4.2.2):
+  /eslint-plugin-svelte@2.34.0(eslint@8.52.0)(svelte@4.2.5):
     resolution: {integrity: sha512-4RYUgNai7wr0v+T/kljMiYSjC/oqwgq5i+cPppawryAayj4C7WK1ixFlWCGmNmBppnoKCl4iA4ZPzPtlHcb4CA==}
     engines: {node: ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1454,8 +1717,8 @@ packages:
       postcss-safe-parser: 6.0.0(postcss@8.4.31)
       postcss-selector-parser: 6.0.13
       semver: 7.5.4
-      svelte: 4.2.2
-      svelte-eslint-parser: 0.33.1(svelte@4.2.2)
+      svelte: 4.2.5
+      svelte-eslint-parser: 0.33.1(svelte@4.2.5)
     transitivePeerDependencies:
       - supports-color
       - ts-node
@@ -1661,15 +1924,15 @@ packages:
       tabbable: 6.2.0
     dev: false
 
-  /formsnap@0.2.0(svelte@4.2.2)(sveltekit-superforms@1.8.0)(zod@3.22.4):
+  /formsnap@0.2.0(svelte@4.2.5)(sveltekit-superforms@1.8.0)(zod@3.22.4):
     resolution: {integrity: sha512-/V6HQTdRCNrDDCvSJVkBl/co0v8D0DkQoAdQCPKZaRagYie1S267BVrpPXmXq2cSj0MH6IvQWojLcTpkEfB9Uw==}
     peerDependencies:
       svelte: ^4.0.0
       sveltekit-superforms: ^1.7.1
       zod: ^3.22.2
     dependencies:
-      svelte: 4.2.2
-      sveltekit-superforms: 1.8.0(@sveltejs/kit@1.26.0)(svelte@4.2.2)(zod@3.22.4)
+      svelte: 4.2.5
+      sveltekit-superforms: 1.8.0(@sveltejs/kit@1.26.0)(svelte@4.2.5)(zod@3.22.4)
       zod: 3.22.4
     dev: false
 
@@ -1843,6 +2106,23 @@ packages:
   /inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
+  /ioredis@5.3.2:
+    resolution: {integrity: sha512-1DKMMzlIHM02eBBVOFQ1+AolGjs6+xEcM4PDL7NqOS6szq7H9jSaEkIUH6/a5Hl241LzW6JLSiAbNvTQjUupUA==}
+    engines: {node: '>=12.22.0'}
+    dependencies:
+      '@ioredis/commands': 1.2.0
+      cluster-key-slot: 1.1.2
+      debug: 4.3.4
+      denque: 2.1.0
+      lodash.defaults: 4.2.0
+      lodash.isarguments: 3.1.0
+      redis-errors: 1.2.0
+      redis-parser: 3.0.0
+      standard-as-callback: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /is-binary-path@2.1.0:
     resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
     engines: {node: '>=8'}
@@ -1987,6 +2267,14 @@ packages:
       p-locate: 5.0.0
     dev: true
 
+  /lodash.defaults@4.2.0:
+    resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
+    dev: false
+
+  /lodash.isarguments@3.1.0:
+    resolution: {integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==}
+    dev: false
+
   /lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
     dev: true
@@ -2018,12 +2306,12 @@ packages:
     resolution: {integrity: sha512-EHDTajS1YWA7Q37jd29Far1l4nfZgsWLp4hDQeaQhVpJd2WKQqA3626kJYmOj1CTweVMkE54xFi5JIph+agZkQ==}
     dev: false
 
-  /lucide-svelte@0.288.0(svelte@4.2.2):
+  /lucide-svelte@0.288.0(svelte@4.2.5):
     resolution: {integrity: sha512-rgpEAifh+Xs6aRCk3PmNO1yAMF7E3764fRvTDj1BSEI9VdfDQIabjx07Uh8KeMy2SB9dmp565F/H3fHTWQ49fw==}
     peerDependencies:
       svelte: '>=3 <5'
     dependencies:
-      svelte: 4.2.2
+      svelte: 4.2.5
     dev: false
 
   /magic-string@0.27.0:
@@ -2136,6 +2424,12 @@ packages:
   /nanoid@4.0.2:
     resolution: {integrity: sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==}
     engines: {node: ^14 || ^16 || >=18}
+    hasBin: true
+    dev: false
+
+  /nanoid@5.0.3:
+    resolution: {integrity: sha512-I7X2b22cxA4LIHXPSqbBCEQSL+1wv8TuoefejsX4HFWyC6jc5JG7CEaxOltiKjc1M+YCS2YkrZZcj4+dytw9GA==}
+    engines: {node: ^18 || >=20}
     hasBin: true
     dev: false
 
@@ -2396,14 +2690,14 @@ packages:
     engines: {node: '>= 0.8.0'}
     dev: true
 
-  /prettier-plugin-svelte@2.10.1(prettier@2.8.8)(svelte@4.2.2):
+  /prettier-plugin-svelte@2.10.1(prettier@2.8.8)(svelte@4.2.5):
     resolution: {integrity: sha512-Wlq7Z5v2ueCubWo0TZzKc9XHcm7TDxqcuzRuGd0gcENfzfT4JZ9yDlCbEgxWgiPmLHkBjfOtpAWkcT28MCDpUQ==}
     peerDependencies:
       prettier: ^1.16.4 || ^2.0.0
       svelte: ^3.2.0 || ^4.0.0-next.0
     dependencies:
       prettier: 2.8.8
-      svelte: 4.2.2
+      svelte: 4.2.5
     dev: true
 
   /prettier@2.8.8:
@@ -2592,6 +2886,10 @@ packages:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
     dev: true
 
+  /standard-as-callback@2.1.0:
+    resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
+    dev: false
+
   /std-env@3.4.3:
     resolution: {integrity: sha512-f9aPhy8fYBuMN+sNfakZV18U39PbalgjXG3lLB9WkaYTxijru61wb57V9wxxNthXM5Sd88ETBWi29qLAsHO52Q==}
     dev: true
@@ -2645,7 +2943,7 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  /svelte-check@3.5.2(postcss-load-config@4.0.1)(postcss@8.4.31)(svelte@4.2.2):
+  /svelte-check@3.5.2(postcss-load-config@4.0.1)(postcss@8.4.31)(svelte@4.2.5):
     resolution: {integrity: sha512-5a/YWbiH4c+AqAUP+0VneiV5bP8YOk9JL3jwvN+k2PEPLgpu85bjQc5eE67+eIZBBwUEJzmO3I92OqKcqbp3fw==}
     hasBin: true
     peerDependencies:
@@ -2657,8 +2955,8 @@ packages:
       import-fresh: 3.3.0
       picocolors: 1.0.0
       sade: 1.8.1
-      svelte: 4.2.2
-      svelte-preprocess: 5.0.4(postcss-load-config@4.0.1)(postcss@8.4.31)(svelte@4.2.2)(typescript@5.2.2)
+      svelte: 4.2.5
+      svelte-preprocess: 5.0.4(postcss-load-config@4.0.1)(postcss@8.4.31)(svelte@4.2.5)(typescript@5.2.2)
       typescript: 5.2.2
     transitivePeerDependencies:
       - '@babel/core'
@@ -2672,7 +2970,7 @@ packages:
       - sugarss
     dev: true
 
-  /svelte-eslint-parser@0.33.1(svelte@4.2.2):
+  /svelte-eslint-parser@0.33.1(svelte@4.2.5):
     resolution: {integrity: sha512-vo7xPGTlKBGdLH8T5L64FipvTrqv3OQRx9d2z5X05KKZDlF4rQk8KViZO4flKERY+5BiVdOh7zZ7JGJWo5P0uA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -2686,37 +2984,37 @@ packages:
       espree: 9.6.1
       postcss: 8.4.31
       postcss-scss: 4.0.9(postcss@8.4.31)
-      svelte: 4.2.2
+      svelte: 4.2.5
     dev: true
 
-  /svelte-headless-table@0.17.7(svelte@4.2.2):
+  /svelte-headless-table@0.17.7(svelte@4.2.5):
     resolution: {integrity: sha512-GRQEM0c4pXfFs6W+LGbsvrBbDqBaMxxibsWq8Q8o4ve4dTHIC9WsbuKMP3jRHl+iC9jd4K/TXJfLJHtLzuKSQA==}
     peerDependencies:
       svelte: ^3 || ^4
     dependencies:
-      svelte: 4.2.2
-      svelte-keyed: 1.1.7(svelte@4.2.2)
-      svelte-render: 1.6.1(svelte@4.2.2)
-      svelte-subscribe: 1.0.6(svelte@4.2.2)
+      svelte: 4.2.5
+      svelte-keyed: 1.1.7(svelte@4.2.5)
+      svelte-render: 1.6.1(svelte@4.2.5)
+      svelte-subscribe: 1.0.6(svelte@4.2.5)
     dev: true
 
-  /svelte-hmr@0.15.3(svelte@4.2.2):
+  /svelte-hmr@0.15.3(svelte@4.2.5):
     resolution: {integrity: sha512-41snaPswvSf8TJUhlkoJBekRrABDXDMdpNpT2tfHIv4JuhgvHqLMhEPGtaQn0BmbNSTkuz2Ed20DF2eHw0SmBQ==}
     engines: {node: ^12.20 || ^14.13.1 || >= 16}
     peerDependencies:
       svelte: ^3.19.0 || ^4.0.0
     dependencies:
-      svelte: 4.2.2
+      svelte: 4.2.5
 
-  /svelte-keyed@1.1.7(svelte@4.2.2):
+  /svelte-keyed@1.1.7(svelte@4.2.5):
     resolution: {integrity: sha512-d3VIwBza12PIQ0mXf8js+r4xoSFiQikDobbi6hx03oQzZx0BImXCBcdsZeYEN7VrNswXcjIrhc9qqjlxcro49w==}
     peerDependencies:
       svelte: ^3.49.0 || ^4
     dependencies:
-      svelte: 4.2.2
+      svelte: 4.2.5
     dev: true
 
-  /svelte-preprocess@5.0.4(postcss-load-config@4.0.1)(postcss@8.4.31)(svelte@4.2.2)(typescript@5.2.2):
+  /svelte-preprocess@5.0.4(postcss-load-config@4.0.1)(postcss@8.4.31)(svelte@4.2.5)(typescript@5.2.2):
     resolution: {integrity: sha512-ABia2QegosxOGsVlsSBJvoWeXy1wUKSfF7SWJdTjLAbx/Y3SrVevvvbFNQqrSJw89+lNSsM58SipmZJ5SRi5iw==}
     engines: {node: '>= 14.10.0'}
     requiresBuild: true
@@ -2761,29 +3059,29 @@ packages:
       postcss-load-config: 4.0.1(postcss@8.4.31)
       sorcery: 0.11.0
       strip-indent: 3.0.0
-      svelte: 4.2.2
+      svelte: 4.2.5
       typescript: 5.2.2
     dev: true
 
-  /svelte-render@1.6.1(svelte@4.2.2):
+  /svelte-render@1.6.1(svelte@4.2.5):
     resolution: {integrity: sha512-pn580Z6DtxIDrXqQaGR/7z8tdHasgURn1AG5tt4ym1PfE6qFjT27NpN6vIg5kvDl1ewK9pYeTfIWPw4pPXqyuw==}
     peerDependencies:
       svelte: ^3 || ^4
     dependencies:
-      svelte: 4.2.2
-      svelte-subscribe: 1.0.6(svelte@4.2.2)
+      svelte: 4.2.5
+      svelte-subscribe: 1.0.6(svelte@4.2.5)
     dev: true
 
-  /svelte-subscribe@1.0.6(svelte@4.2.2):
+  /svelte-subscribe@1.0.6(svelte@4.2.5):
     resolution: {integrity: sha512-legaLPjOGAN3G6xUa8+1ms3qo3lE4nfypZe1CedyOEoUUwWPfmzJHuBXtwdro4xUf4kezUbzjtyK1UOeZDksog==}
     peerDependencies:
       svelte: ^3 || ^4
     dependencies:
-      svelte: 4.2.2
+      svelte: 4.2.5
     dev: true
 
-  /svelte@4.2.2:
-    resolution: {integrity: sha512-My2tytF2e2NnHSpn2M7/3VdXT4JdTglYVUuSuK/mXL2XtulPYbeBfl8Dm1QiaKRn0zoULRnL+EtfZHHP0k4H3A==}
+  /svelte@4.2.5:
+    resolution: {integrity: sha512-P9YPKsGkNdw4OJbtpd1uzimQHPj7Ai2sPcOHmmD6VgkFhFDmcYevQi7vE4cQ1g8/Vs64aL2TwMoCNFAzv7TPaQ==}
     engines: {node: '>=16'}
     dependencies:
       '@ampproject/remapping': 2.2.1
@@ -2800,15 +3098,15 @@ packages:
       magic-string: 0.30.5
       periscopic: 3.1.0
 
-  /sveltekit-superforms@1.8.0(@sveltejs/kit@1.26.0)(svelte@4.2.2)(zod@3.22.4):
+  /sveltekit-superforms@1.8.0(@sveltejs/kit@1.26.0)(svelte@4.2.5)(zod@3.22.4):
     resolution: {integrity: sha512-ig4SJNe72UNlmL2FjXk6Z3I7WYEm+qerA8PB4WOjQkOirztiDNJrY/bs1lF8VLxc56TSG9JQkCtZkgUdlH3yYA==}
     peerDependencies:
       '@sveltejs/kit': 1.x
       svelte: 3.x || 4.x
       zod: 3.x
     dependencies:
-      '@sveltejs/kit': 1.26.0(svelte@4.2.2)(vite@4.5.0)
-      svelte: 4.2.2
+      '@sveltejs/kit': 1.26.0(svelte@4.2.5)(vite@4.5.0)
+      svelte: 4.2.5
       zod: 3.22.4
     dev: false
 
@@ -2926,6 +3224,14 @@ packages:
 
   /tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
+    dev: true
+
+  /tsm@2.3.0:
+    resolution: {integrity: sha512-++0HFnmmR+gMpDtKTnW3XJ4yv9kVGi20n+NfyQWB9qwJvTaIWY9kBmzek2YUQK5APTQ/1DTrXmm4QtFPmW9Rzw==}
+    engines: {node: '>=12'}
+    hasBin: true
+    dependencies:
+      esbuild: 0.15.18
     dev: true
 
   /type-check@0.4.0:
@@ -3152,6 +3458,19 @@ packages:
 
   /wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  /ws@8.14.2:
+    resolution: {integrity: sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+    dev: false
 
   /yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}

--- a/prod-server.ts
+++ b/prod-server.ts
@@ -1,0 +1,11 @@
+import * as path from 'path';
+import * as url from 'url';
+import { createWSSGlobalInstance, onHttpServerUpgrade } from './src/lib/server/websockets/utils.js';
+
+const __filename = url.fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+createWSSGlobalInstance();
+
+const { server } = await import(path.resolve(__dirname, './build/index.js'));
+server.server.on('upgrade', onHttpServerUpgrade);

--- a/render.yaml
+++ b/render.yaml
@@ -31,8 +31,13 @@ services:
     repo: https://github.com/sammynave/startup.git
     healthCheckPath: /200
     buildCommand: pnpm build:render
-    startCommand: node build/index.js
+    startCommand: pnpm run prod
     envVars:
+      - key: REDIS_WS_SERVER
+        fromService:
+          type: redis
+          name: startup-websocket-redis
+          property: connectionString
       - key: DATABASE_URL
         fromDatabase:
           name: startup-db
@@ -47,6 +52,11 @@ services:
     buildCommand: pnpm build:render
     startCommand: node build/index.js
     envVars:
+      - key: REDIS_WS_SERVER
+        fromService:
+          type: redis
+          name: startup-websocket-redis
+          property: connectionString
       - key: WORKER
         value: true
       - key: DATABASE_URL
@@ -62,6 +72,13 @@ services:
     repo: https://github.com/contribsys/faktory-render
     envVars:
       - fromGroup: startup-env
+
+  - type: redis
+    name: startup-websocket-redis
+    ipAllowList:
+      - source: 0.0.0.0/0
+        description: everywhere
+    plan: free
 
 # startup-env group example
 # FAKTORY_PASSWORD=some_password

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -1,6 +1,7 @@
 // See https://kit.svelte.dev/docs/types#app
 
 import type { userRoles } from '$lib/server/db/schema';
+import type { ExtendedWebSocketServer } from '$lib/server/websockets/utils';
 import type { Session } from 'lucia';
 
 // for information about these interfaces
@@ -12,6 +13,7 @@ declare global {
 		interface Locals {
 			auth: import('lucia').AuthRequest;
 			user: Session['user'];
+			wss?: ExtendedWebSocketServer;
 		}
 	}
 }

--- a/src/lib/components/ui/tabs/tabs-trigger.svelte
+++ b/src/lib/components/ui/tabs/tabs-trigger.svelte
@@ -18,7 +18,7 @@
 	{value}
 	{...$$restProps}
 	on:click
-	on:focusin
+	on:focus
 >
 	<slot />
 </TabsPrimitive.Trigger>

--- a/src/lib/server/websockets/chat.ts
+++ b/src/lib/server/websockets/chat.ts
@@ -1,0 +1,112 @@
+import type { Redis } from 'ioredis';
+import { client, pubClient, subClient } from './redis-client';
+import type { ExtendedWebSocketServer } from './utils';
+import { WebSocket } from 'ws';
+
+export class Chat {
+	wss: ExtendedWebSocketServer;
+	channel: string;
+	redisChannel: string;
+	redisClient: Redis;
+	sub: Redis;
+	pub: Redis;
+
+	private constructor({
+		wss,
+		channel,
+		pub,
+		sub,
+		redisClient
+	}: {
+		wss: ExtendedWebSocketServer;
+		channel: string;
+		pub: Redis;
+		sub: Redis;
+		redisClient: Redis;
+	}) {
+		this.wss = wss;
+		this.channel = channel;
+		this.redisChannel = `chat_messages:${channel}`;
+		this.sub = sub;
+		this.pub = pub;
+		this.redisClient = redisClient;
+	}
+
+	static async init({ wss, channel }: { wss: ExtendedWebSocketServer; channel: string }) {
+		const redisClient = client();
+		const pub = pubClient();
+		const sub = subClient();
+
+		const chat = new Chat({ wss, channel, pub, sub, redisClient });
+
+		const currentSubscriptions = await pub.pubsub('CHANNELS');
+
+		if (!currentSubscriptions.includes(chat.redisChannel)) {
+			// Don't over subscribe.
+			// WARNING: any changes to this block will not get picked up during HMR.
+			// restart server (or remove `if` statement)
+			// NOTE if you remove the `if` then you will have multiple subscribers and you will get duplicate socket messages)
+			sub.subscribe(chat.redisChannel, (err) => {
+				if (err) {
+					console.error('Failed to subscribe: %s', err.message);
+				}
+			});
+			sub.on('message', (redisChannel, message) => {
+				if (redisChannel === chat.redisChannel) {
+					chat.notifyClients(message);
+				}
+			});
+		}
+
+		return chat;
+	}
+
+	private notifyClients(message: string) {
+		this.wss.clients.forEach((client) => {
+			if (client.readyState === WebSocket.OPEN && client.channel === this.channel) {
+				client.send(message, { binary: false });
+			}
+		});
+	}
+
+	private notifySelf(message: string, sessionId: string) {
+		this.wss.clients.forEach((client) => {
+			if (
+				client.readyState === WebSocket.OPEN &&
+				sessionId === client.session.sessionId &&
+				client.channel === this.channel
+			) {
+				client.send(message, { binary: false });
+			}
+		});
+	}
+
+	async connected(username: string) {
+		const message = JSON.stringify({
+			type: 'connect',
+			channel: this.channel,
+			message: `${username} connected`
+		});
+		await this.pub.publish(this.redisChannel, message);
+	}
+
+	async disconnected(username: string) {
+		const message = JSON.stringify({
+			type: 'disconnect',
+			channel: this.channel,
+			message: `${username} disconnected`
+		});
+		await this.pub.publish(this.redisChannel, message);
+	}
+
+	async received({ username, message }: { username: string; message: string }) {
+		const chatMessage = JSON.stringify({
+			type: 'message',
+			channel: this.channel,
+			username,
+			message
+		});
+		await this.redisClient.lpush(this.redisChannel, chatMessage);
+		await this.pub.publish(this.redisChannel, chatMessage);
+	}
+}

--- a/src/lib/server/websockets/handler.ts
+++ b/src/lib/server/websockets/handler.ts
@@ -1,0 +1,62 @@
+import { auth } from '../lucia';
+import WebSocket from 'ws';
+import type { ExtendedWebSocket, ExtendedWebSocketServer } from './utils';
+import type { IncomingMessage } from 'http';
+import { Presence } from './presence';
+import { Chat } from './chat';
+
+export function reloadAllClients(wss: ExtendedWebSocketServer) {
+	return function (channel: string) {
+		wss.clients.forEach((client) => {
+			if (client.readyState === WebSocket.OPEN) {
+				client.send(JSON.stringify({ type: 'reload', channel }), {
+					binary: false
+				});
+			}
+		});
+	};
+}
+
+function channelFrom(request: IncomingMessage) {
+	const url = new URL(`${request.headers.origin}${request.url}`);
+	return url.searchParams.get('channel');
+}
+
+async function sessionFrom(request: IncomingMessage) {
+	const sessionId = auth.readSessionCookie(request.headers.cookie);
+	return sessionId ? await auth.validateSession(sessionId) : null; // note: `validateSession()` throws an error if session is invalid
+}
+
+export const connectionHandler =
+	(wss: ExtendedWebSocketServer) => async (ws: ExtendedWebSocket, request: IncomingMessage) => {
+		const channel = channelFrom(request);
+		if (channel === null) {
+			ws.close(1008, 'No channel specified');
+			return;
+		}
+
+		const session = await sessionFrom(request);
+
+		if (session) {
+			ws.session = session;
+			ws.channel = channel;
+		} else {
+			ws.close(1008, 'User not authenticated');
+			return;
+		}
+
+		const chat = await Chat.init({ wss, channel });
+		const presence = await Presence.init({ wss, channel });
+
+		await presence.add(session.user.username);
+		await chat.connected(session.user.username);
+
+		ws.on('message', async (data: string) => {
+			const { message } = JSON.parse(data);
+			await chat.received({ username: session.user.username, message });
+		});
+		ws.on('close', async () => {
+			await chat.disconnected(session.user.username);
+			await presence.remove(session.user.username);
+		});
+	};

--- a/src/lib/server/websockets/presence.ts
+++ b/src/lib/server/websockets/presence.ts
@@ -1,0 +1,95 @@
+import type { Redis } from 'ioredis';
+import type { ExtendedWebSocketServer } from './utils';
+import { pubClient, subClient } from './redis-client';
+import { WebSocket } from 'ws';
+
+export class Presence {
+	wss: ExtendedWebSocketServer;
+	channel: string;
+	redisChannel: string;
+	sub: Redis;
+	pub: Redis;
+
+	private constructor({
+		wss,
+		channel,
+		pub,
+		sub
+	}: {
+		wss: ExtendedWebSocketServer;
+		channel: string;
+		pub: Redis;
+		sub: Redis;
+	}) {
+		this.wss = wss;
+		this.channel = channel;
+		this.redisChannel = `presence:${channel}`;
+		this.sub = sub;
+		this.pub = pub;
+	}
+
+	static async init({ wss, channel }: { wss: ExtendedWebSocketServer; channel: string }) {
+		const pub = pubClient();
+		const sub = subClient();
+
+		const currentSubscriptions = await pub.pubsub('CHANNELS');
+		const presence = new Presence({ wss, channel, pub, sub });
+
+		if (!currentSubscriptions.includes(presence.redisChannel)) {
+			// Don't over subscribe.
+			// WARNING: any changes to this block will not get picked up during HMR.
+			// restart server (or remove `if` statement)
+			// NOTE if you remove the `if` then you will have multiple subscribers and you will get duplicate socket messages)
+			sub.subscribe(presence.redisChannel, (err) => {
+				if (err) {
+					console.error('Failed to subscribe: %s', err.message);
+				}
+			});
+
+			sub.on('message', (redisChannel, message) => {
+				if (presence.redisChannel === redisChannel) {
+					// this is sendPresentUsers
+					presence.notifyClients(JSON.parse(message));
+				}
+			});
+		}
+
+		return presence;
+	}
+
+	private notifyClients(message: string) {
+		this.wss.clients.forEach((client) => {
+			if (client.readyState === WebSocket.OPEN && client.channel === this.channel) {
+				client.send(
+					JSON.stringify({
+						type: 'presence',
+						channel: this.channel,
+						message
+					}),
+					{ binary: false }
+				);
+			}
+		});
+	}
+
+	async presentUsers() {
+		// return all entries in zrange sorted by oldest first
+		return await this.pub.zrange(this.redisChannel, -Infinity, +Infinity, 'BYSCORE');
+	}
+
+	async add(username: string) {
+		// Insert username at current timestamp in zrange
+		await this.pub.zadd(this.redisChannel, Date.now(), username);
+		this.notify();
+	}
+
+	async remove(username: string) {
+		await this.pub.zrem(this.redisChannel, username);
+		this.notify();
+	}
+
+	async notify() {
+		const presentUsers = await this.presentUsers();
+		await this.pub.publish(this.redisChannel, JSON.stringify(presentUsers));
+	}
+}

--- a/src/lib/server/websockets/redis-client.ts
+++ b/src/lib/server/websockets/redis-client.ts
@@ -1,0 +1,21 @@
+import Redis from 'ioredis';
+import { REDIS_WS_SERVER } from '$env/static/private';
+
+let pub: Redis | null = null;
+let sub: Redis | null = null;
+let cli: Redis | null = null;
+
+export const pubClient = () => {
+	pub = pub ? pub : new Redis(REDIS_WS_SERVER);
+	return pub;
+};
+
+export const subClient = () => {
+	sub = sub ? sub : new Redis(REDIS_WS_SERVER);
+	return sub;
+};
+
+export const client = () => {
+	cli = cli ? cli : new Redis(REDIS_WS_SERVER);
+	return cli;
+};

--- a/src/lib/server/websockets/utils.ts
+++ b/src/lib/server/websockets/utils.ts
@@ -1,0 +1,67 @@
+import { URL } from 'url';
+import { WebSocketServer } from 'ws';
+import { nanoid } from 'nanoid';
+import type { Server, WebSocket } from 'ws';
+import type { IncomingMessage } from 'http';
+import type { Duplex } from 'stream';
+import type { Session } from 'lucia';
+
+export declare class ExtendedWebSocket extends WebSocket {
+	socketId: string;
+	session: Session;
+	channel: string;
+}
+
+export const GlobalThisWSS = Symbol.for('sveltekit.wss');
+
+export type ExtendedWebSocketServer = Server<typeof ExtendedWebSocket>;
+
+export type ExtendedGlobal = typeof globalThis & {
+	[GlobalThisWSS]: ExtendedWebSocketServer;
+};
+
+export const getWss = () => (globalThis as ExtendedGlobal)[GlobalThisWSS];
+export const setWss = (wss: ExtendedWebSocketServer) => {
+	(globalThis as ExtendedGlobal)[GlobalThisWSS] = wss;
+	return wss;
+};
+
+const isUrl = (url: string) => {
+	try {
+		new URL(url);
+		return true;
+	} catch {
+		return false;
+	}
+};
+
+export const onHttpServerUpgrade = (req: IncomingMessage, sock: Duplex, head: Buffer) => {
+	const pathname = req.url && isUrl(req.url) ? new URL(req.url).pathname : null;
+
+	if (pathname === '/websocket' || req.url?.includes('/websocket')) {
+		const wss = getWss();
+
+		wss.handleUpgrade(req, sock, head, (ws) => {
+			wss.emit('connection', ws, req);
+		});
+	}
+};
+
+export const createWSSGlobalInstance = () => {
+	if (process.env.WORKER) {
+		return;
+	}
+
+	const wss = setWss(new WebSocketServer({ noServer: true }));
+
+	wss.on('connection', (ws) => {
+		ws.socketId = nanoid();
+		console.log(`[wss:global] client connected (${ws.socketId})`);
+
+		ws.on('close', () => {
+			console.log(`[wss:global] client disconnected (${ws.socketId})`);
+		});
+	});
+
+	return wss;
+};

--- a/src/lib/websockets/chat-store.ts
+++ b/src/lib/websockets/chat-store.ts
@@ -1,0 +1,43 @@
+import { derived } from 'svelte/store';
+import type { wsStore } from './ws-store';
+
+export type Message = {
+	message: string;
+	type?: 'message' | 'disconnect' | 'connect';
+	username?: string;
+};
+export function chatStore(ws: ReturnType<typeof wsStore>, initialValue: Message[]) {
+	const messages = derived(
+		ws,
+		($ws, set) => {
+			let listenerAdded = false;
+			if ($ws && !listenerAdded) {
+				let messages: Message[] = initialValue;
+				const addMessage = (message: Message) => {
+					messages = [...messages, message];
+				};
+				$ws.addEventListener('message', (event) => {
+					listenerAdded = true;
+					if (typeof event.data === 'string') {
+						const data = JSON.parse(event.data);
+						if (['message', 'connect', 'disconnect'].includes(data.type)) {
+							addMessage(data);
+							set(messages);
+						}
+					}
+				});
+			}
+		},
+		initialValue
+	);
+
+	return {
+		subscribe: messages.subscribe,
+		send(message: string) {
+			if (!ws) {
+				throw 'No websocket connection!';
+			}
+			ws.send(JSON.stringify({ type: 'chat', message }));
+		}
+	};
+}

--- a/src/lib/websockets/presence-store.ts
+++ b/src/lib/websockets/presence-store.ts
@@ -1,0 +1,23 @@
+import { derived } from 'svelte/store';
+import type { wsStore } from './ws-store';
+
+export function presenceStore(ws: ReturnType<typeof wsStore>, initialValue: string[]) {
+	return derived(
+		ws,
+		($ws, set) => {
+			let listenerAdded = false;
+			if ($ws && !listenerAdded) {
+				$ws.addEventListener('message', (event) => {
+					listenerAdded = true;
+					if (typeof event.data === 'string') {
+						const data = JSON.parse(event.data);
+						if (data.type === 'presence') {
+							set(data.message);
+						}
+					}
+				});
+			}
+		},
+		initialValue
+	);
+}

--- a/src/lib/websockets/reload-store.ts
+++ b/src/lib/websockets/reload-store.ts
@@ -1,0 +1,20 @@
+import { derived } from 'svelte/store';
+import type { wsStore } from './ws-store';
+
+export function reloadStore(ws: ReturnType<typeof wsStore>) {
+	return derived(ws, ($ws) => {
+		let listenerAdded = false;
+		if ($ws && !listenerAdded) {
+			$ws.addEventListener('message', (event) => {
+				listenerAdded = true;
+				if (typeof event.data === 'string') {
+					const data = JSON.parse(event.data);
+					if (data.type === 'reload') {
+						console.log('reloading');
+						window.location.reload();
+					}
+				}
+			});
+		}
+	});
+}

--- a/src/lib/websockets/ws-store.ts
+++ b/src/lib/websockets/ws-store.ts
@@ -1,0 +1,54 @@
+import { browser } from '$app/environment';
+import { page } from '$app/stores';
+import { get } from 'svelte/store';
+
+type Subscription = (value: WebSocket | null) => void;
+export function wsStore({ channel }: { channel: string }) {
+	const subscriptions = new Set<Subscription>();
+
+	let ws: WebSocket | null = null;
+
+	function open() {
+		if (ws) {
+			return;
+		}
+		const { protocol, host } = get(page).url;
+		const wsProtocol = protocol === 'https:' ? 'wss:' : 'ws:';
+		const url = `${wsProtocol}//${host}/websocket?channel=${channel}`;
+		ws = new WebSocket(url);
+		ws.addEventListener('error', (error) => console.error(error));
+		ws.addEventListener('open', () => subscriptions.forEach((subscription) => subscription(ws)));
+	}
+
+	function close() {
+		if (ws) {
+			ws.close();
+			ws = null;
+		}
+	}
+
+	return {
+		subscribe(subscription: Subscription) {
+			if (browser) {
+				open();
+			}
+			subscriptions.add(subscription);
+			return () => {
+				subscriptions.delete(subscription);
+				if (subscriptions.size === 0) {
+					close();
+				}
+			};
+		},
+
+		// Generic send, can be customized/extended from custom store
+		// see `send` in `chat-store` for example
+		send(message: string) {
+			if (!ws) {
+				throw 'No websocket connection!';
+			}
+
+			ws.send(message);
+		}
+	};
+}

--- a/src/routes/app/+layout.svelte
+++ b/src/routes/app/+layout.svelte
@@ -58,6 +58,15 @@
 					<Sheet.Close asChild let:builder>
 						<Button
 							builders={[builder]}
+							class={(routeId === '/app/websocket-example' ? 'underline ' : ' ') +
+								'w-full justify-start'}
+							variant="link"
+							href="/app/websocket-example">Websocket example</Button
+						>
+					</Sheet.Close>
+					<Sheet.Close asChild let:builder>
+						<Button
+							builders={[builder]}
 							class={(routeId === '/app/settings' ? 'underline ' : ' ') + 'w-full justify-start'}
 							variant="link"
 							href="/app/settings">Settings</Button
@@ -82,6 +91,11 @@
 			class={routeId === '/app/example-background-job' ? 'underline' : ''}
 			variant="link"
 			href="/app/example-background-job">Example background job</Button
+		>
+		<Button
+			class={routeId === '/app/websocket-example' ? 'underline' : ''}
+			variant="link"
+			href="/app/websocket-example">Websocket example</Button
 		>
 		<Button
 			class={routeId === '/app/settings' ? 'underline' : ''}

--- a/src/routes/app/example-background-job/+page.svelte
+++ b/src/routes/app/example-background-job/+page.svelte
@@ -19,6 +19,7 @@
 			Click the button below to queue up an example background job. You can queue up as many as you
 			like! If you haven't started any workers yet, you can view them in the
 			<a class="underline" href={`${PUBLIC_FAKTORY_URL}/queues/default`}>Faktory UI.</a>
+			(username can be anything; password = "some_password")
 		</P>
 
 		<P>Start a worker (`pnpm dev:worker`) to process the queue</P>

--- a/src/routes/app/websocket-example/+page.server.ts
+++ b/src/routes/app/websocket-example/+page.server.ts
@@ -1,0 +1,26 @@
+import { reloadAllClients } from '$lib/server/websockets/handler';
+import type { Actions } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types';
+import { client } from '$lib/server/websockets/redis-client';
+import type { Message } from '$lib/websockets/chat-store';
+
+const redisClient = client();
+
+export const load: PageServerLoad = async ({ locals }) => {
+	const { username } = locals.user;
+	const messages = (await redisClient.lrange(`chat_messages:chat`, 0, -1)) as unknown as string[];
+
+	return {
+		username,
+		messages: messages.reverse().map((message) => JSON.parse(message)) as Message[]
+	};
+};
+export const actions: Actions = {
+	default: async ({ locals }) => {
+		if (locals.wss) {
+			redisClient.flushall();
+			reloadAllClients(locals.wss)('chat');
+		}
+		return true;
+	}
+};

--- a/src/routes/app/websocket-example/+page.svelte
+++ b/src/routes/app/websocket-example/+page.svelte
@@ -1,0 +1,81 @@
+<script lang="ts">
+	import { enhance } from '$app/forms';
+	import Button from '$lib/components/ui/button/button.svelte';
+	import * as Card from '$lib/components/ui/card';
+	import Input from '$lib/components/ui/input/input.svelte';
+	import Label from '$lib/components/ui/label/label.svelte';
+	import Separator from '$lib/components/ui/separator/separator.svelte';
+	import { chatStore } from '$lib/websockets/chat-store.js';
+	import { presenceStore } from '$lib/websockets/presence-store.js';
+	import { reloadStore } from '$lib/websockets/reload-store.js';
+	import { wsStore } from '$lib/websockets/ws-store.js';
+	import type { FormEvent } from 'formsnap/dist/internal';
+
+	export let data;
+
+	const channel = 'chat';
+	const ws = wsStore({ channel });
+	const chat = chatStore(ws, data.messages);
+	const presence = presenceStore(ws, []);
+	const reload = reloadStore(ws);
+
+	let message = '';
+	let sending = false;
+
+	async function send(e: FormEvent) {
+		e.preventDefault();
+		if (sending || message.length === 0) {
+			return;
+		}
+
+		try {
+			sending = true;
+			chat.send(message);
+			message = '';
+		} finally {
+			sending = false;
+		}
+	}
+</script>
+
+<Card.Root class="min-w-min md:w-[80%] lg:w-[60%] mx-auto border-none shadow-none">
+	<Card.Header class="flex flex-row items-center justify-between">
+		<Card.Title>SvelteKit with WebSocket Integration</Card.Title>
+		<span>{$presence.join(', ')}</span>
+		<form method="post" use:enhance>
+			<Button type="submit">Delete chat history</Button>
+		</form>
+	</Card.Header>
+	<Separator />
+	<Card.Content class="flex flex-col-reverse overflow-y-auto max-h-[50vh] p-4">
+		<ul class="flex flex-col">
+			{#each $chat as message}
+				{#if message?.username === data.username}
+					<li class="bg-slate-200 self-end p-2 mb-2">{message.message}</li>
+				{:else if message?.username}
+					<li class="p-2 mb-2">{message.username}: {message.message}</li>
+				{:else}
+					<li class="bg-green-200 p-2 mb-2">{message.message}</li>
+				{/if}
+			{:else}
+				No messages
+			{/each}
+		</ul>
+	</Card.Content>
+	<Separator />
+	<Card.Footer class="pt-4">
+		<form on:submit={send} class="w-full">
+			<Label for="message">message</Label>
+			<Input class="mt-2" id="message" name="message" type="text" bind:value={message} />
+			<Button class="mt-2" type="submit" disabled={sending}>Send</Button>
+		</form>
+		<!-- need to reference the reload store. otherwise the compiler removes it -->
+		<span class="hidden">{$reload}</span>
+	</Card.Footer>
+</Card.Root>
+
+<style>
+	li {
+		transform: translateZ(0);
+	}
+</style>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,22 @@
+import { createWSSGlobalInstance, onHttpServerUpgrade } from './src/lib/server/websockets/utils';
 import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
-	plugins: [sveltekit()],
+	plugins: [
+		sveltekit(),
+		{
+			name: 'integratedWebsocketServer',
+			configureServer(server) {
+				createWSSGlobalInstance();
+				server.httpServer?.on('upgrade', onHttpServerUpgrade);
+			},
+			configurePreviewServer(server) {
+				createWSSGlobalInstance();
+				server.httpServer?.on('upgrade', onHttpServerUpgrade);
+			}
+		}
+	],
 	test: {
 		include: ['src/**/*.{test,spec}.{js,ts}']
 	}


### PR DESCRIPTION
This repo contains an example (`/src/routes/app/websocket-example` -> `http://localhost:5173/app/websocket-example`) of how to setup websockets on the same port in the same process as the svelte server. (taken from this repo)[https://github.com/suhaildawood/SvelteKit-integrated-WebSocket].

Key files:

-  `prod-server.ts` - this is how you'll start your prod server (see `render.yaml`)
-  `vite.config.ts` - here we create a small plugin to insert the websocket server at `/websocket` path for the dev and preview servers (`configureServer` and `configurePreviewServer`)
-  `src/lib/server/websockets/utils.ts` - this file contains the functions that create the server (`createWSSGlobalInstance`) and host it (`onHttpServerUpgrade`) referenced in the step above. This technique relies on attaching the websocket server to the global state. This file also has two utility functions to help out when getting and setting the websocket server: `getWss` and `setWss`
-  `src/hooks.server.ts` - this file initializes our websocket server and adds a reference to it to `locals`. this way we can trigger events from other places in our Svelte server, for example, the default action in `src/routes/app/websocket-example/+page.server.ts`. Here we're grabbing the server (`wss`) off of the `event.locals` object and then triggering a reload for all of our connected clients.

Example files that make use of this setup:

`src/lib/server/websockets` - this directory contains an example of how one might implement a chat room example and a "presence" example (i.e. who else is here?).

- `handler.ts` - this file is responsible for setting up client connections. it handles session auth (via `Lucia`) and it set ups and coordinates the features we want to use over websockets (`Chat` and `Presence`)
- `chat.ts` and `presence.ts` are examples of how one might group together concerns into separate files/stay organized and still be able to share a single socket per client. they make use of Redis' `pub/sub` feature so we can scale across multiple instances of this server. (NOTE: Redis' Pub/Sub exhibits **at-most-once** message delivery semantics, meaning if a message is published and there are no subscribers connected, it will never be delivered. If your app requires stronger delivery guarantees. Look into (Redis Streams)[https://redis.io/docs/data-types/streams/]. Messages in streams are persisted, and support both at-most-once as well as at-least-once delivery semantics. TODO: maybe make Streams the default implementation or look into using Postgres' pub/sub. Getting rid of the Redis infrastructure might be worth it 🤷‍♂️)
- `redis-client.ts` - since you can't use the same Redis client for both publish and subscribe, this file just exports 3 different clients that can be reused throughout the app

`src/lib/websockets` - this directory contains all of the client side examples for implementing chat and "presence".

- `ws-store.ts` - this is a custom Svelte store that handles setting up the websocket and sending messages to the server
- `chat-store.ts` - this is a custom Svelte store (with an embedded `derived` store using `ws-store`) to add a listener to `ws-store` to handle receiving chat related messages. it also exports a `send` method for sending messages to the chat channel
- `presence-store.ts` - this is a `derived` store that adds a listener to `ws-store` for `type: 'presence'` messages.
- `reload-store.ts` - this was useful for debugging/developing these examples - it's also a `derived` store and used for flushing the Redis cache (i.e. deleting all chat messages) and force-reloading all connected clients.